### PR TITLE
Spring clean

### DIFF
--- a/src/main/scala/no/ndla/oembedproxy/ComponentRegistry.scala
+++ b/src/main/scala/no/ndla/oembedproxy/ComponentRegistry.scala
@@ -18,7 +18,7 @@ object ComponentRegistry
     with NdlaClient
     with ProviderService
     with HealthController {
-  implicit val swagger = new OEmbedSwagger
+  implicit val swagger: OEmbedSwagger = new OEmbedSwagger
 
   lazy val providerService = new ProviderService
   lazy val oEmbedService = new OEmbedService

--- a/src/main/scala/no/ndla/oembedproxy/OEmbedProxyProperties.scala
+++ b/src/main/scala/no/ndla/oembedproxy/OEmbedProxyProperties.scala
@@ -47,8 +47,7 @@ object OEmbedProxyProperties {
   val NdlaApprovedUrl = Map(
     "local" -> List("http://localhost/*", "http://localhost:30017/*", "http://ndla-frontend.ndla-local/*"),
     "prod" -> List("https?://www.ndla.no/*", "https?://ndla.no/*", "https?://beta.ndla.no/*")
-  ).getOrElse(Environment,
-              List(s"https?://ndla-frontend.$Environment.api.ndla.no/*", s"https?://$Environment.ndla.no/*"))
+  ).getOrElse(Environment, List(s"https?://ndla-frontend.$Environment.ndla.no/*", s"https?://$Environment.ndla.no/*"))
 
   val NdlaH5POembedProvider = Map(
     "staging" -> "https://h5p-staging.ndla.no",

--- a/src/main/scala/no/ndla/oembedproxy/OEmbedProxyProperties.scala
+++ b/src/main/scala/no/ndla/oembedproxy/OEmbedProxyProperties.scala
@@ -13,11 +13,11 @@ import scala.util.Properties.envOrNone
 
 object OEmbedProxyProperties {
 
-  val ApplicationPort = propOrElse("APPLICATION_PORT", "80").toInt
+  val ApplicationPort: Int = propOrElse("APPLICATION_PORT", "80").toInt
 
   val CorrelationIdKey = "correlationID"
   val CorrelationIdHeader = "X-Correlation-ID"
-  val Environment = propOrElse("NDLA_ENVIRONMENT", "local")
+  val Environment: String = propOrElse("NDLA_ENVIRONMENT", "local")
 
   val Auth0LoginEndpoint =
     s"https://${AuthUser.getAuth0HostForEnv(Environment)}/authorize"
@@ -27,35 +27,35 @@ object OEmbedProxyProperties {
   val ProviderListCacheAgeInMs: Long = 1000 * 60 * 60 * 24 // 24 hour caching
   val ProviderListRetryTimeInMs: Long = 1000 * 60 * 60 // 1 hour before retrying a failed attempt.
 
-  val NdlaApiOembedServiceUrl = Map(
+  val NdlaApiOembedServiceUrl: String = Map(
     "local" -> "http://ndla-frontend.ndla-local/oembed",
     "prod" -> "https://ndla.no/oembed"
   ).getOrElse(Environment, s"https://$Environment.ndla.no/oembed")
 
-  val ListingFrontendOembedServiceUrl = Map(
-    "local" -> "http://localhost:30020/oembed",
+  val ListingFrontendOembedServiceUrl: String = Map(
+    "local" -> "http://listing-frontend.ndla-local/oembed",
     "prod" -> "https://liste.ndla.no/oembed"
   ).getOrElse(Environment, s"https://liste.$Environment.ndla.no/oembed")
 
-  val ListingFrontendApprovedUrls = Map(
-    "local" -> List("http://localhost:30020/*"),
+  val ListingFrontendApprovedUrls: List[String] = Map(
+    "local" -> List("http://localhost:30020/*", "http://listing-frontend.ndla-local/*"),
     "prod" -> List("https?://liste.ndla.no/*")
   ).getOrElse(Environment, List(s"https?://liste.$Environment.ndla.no/*"))
 
-  val NdlaApiOembedProvider = Domain
+  val NdlaApiOembedProvider: String = Domain
 
-  val NdlaApprovedUrl = Map(
-    "local" -> List("http://localhost/*", "http://localhost:30017/*", "http://ndla-frontend.ndla-local/*"),
+  val NdlaApprovedUrl: List[String] = Map(
+    "local" -> List("http://localhost:30017/*", "http://ndla-frontend.ndla-local/*"),
     "prod" -> List("https?://www.ndla.no/*", "https?://ndla.no/*", "https?://beta.ndla.no/*")
   ).getOrElse(Environment, List(s"https?://ndla-frontend.$Environment.ndla.no/*", s"https?://$Environment.ndla.no/*"))
 
-  val NdlaH5POembedProvider = Map(
+  val NdlaH5POembedProvider: String = Map(
     "staging" -> "https://h5p-staging.ndla.no",
     "prod" -> "https://h5p.ndla.no",
     "ff" -> "https://h5p-ff.ndla.no"
   ).getOrElse(Environment, "https://h5p-test.ndla.no")
 
-  val NdlaH5PApprovedUrl = Map(
+  val NdlaH5PApprovedUrl: String = Map(
     "staging" -> "https://h5p-staging.ndla.no/resource/*",
     "prod" -> "https://h5p.ndla.no/resource/*",
     "ff" -> "https://h5p-ff.ndla.no/resource/*"
@@ -65,7 +65,7 @@ object OEmbedProxyProperties {
   val ResourcesAppMountPoint = "/oembed-proxy/api-docs"
   val HealthControllerMountPoint = "/health"
 
-  lazy val Domain = Domains.get(Environment)
+  lazy val Domain: String = Domains.get(Environment)
 
   def propOrElse(key: String, default: => String): String = {
     envOrNone(key) match {

--- a/src/main/scala/no/ndla/oembedproxy/OEmbedProxyProperties.scala
+++ b/src/main/scala/no/ndla/oembedproxy/OEmbedProxyProperties.scala
@@ -27,7 +27,7 @@ object OEmbedProxyProperties {
   val ProviderListCacheAgeInMs: Long = 1000 * 60 * 60 * 24 // 24 hour caching
   val ProviderListRetryTimeInMs: Long = 1000 * 60 * 60 // 1 hour before retrying a failed attempt.
 
-  val NdlaApiOembedServiceUrl: String = Map(
+  val NdlaFrontendOembedServiceUrl: String = Map(
     "local" -> "http://ndla-frontend.ndla-local/oembed",
     "prod" -> "https://ndla.no/oembed"
   ).getOrElse(Environment, s"https://$Environment.ndla.no/oembed")
@@ -52,13 +52,11 @@ object OEmbedProxyProperties {
   val NdlaH5POembedProvider: String = Map(
     "staging" -> "https://h5p-staging.ndla.no",
     "prod" -> "https://h5p.ndla.no",
-    "ff" -> "https://h5p-ff.ndla.no"
   ).getOrElse(Environment, "https://h5p-test.ndla.no")
 
   val NdlaH5PApprovedUrl: String = Map(
     "staging" -> "https://h5p-staging.ndla.no/resource/*",
     "prod" -> "https://h5p.ndla.no/resource/*",
-    "ff" -> "https://h5p-ff.ndla.no/resource/*"
   ).getOrElse(Environment, "https://h5p-test.ndla.no/resource/*")
 
   val OembedProxyControllerMountPoint = "/oembed-proxy/v1/oembed"

--- a/src/main/scala/no/ndla/oembedproxy/OEmbedSwagger.scala
+++ b/src/main/scala/no/ndla/oembedproxy/OEmbedSwagger.scala
@@ -19,18 +19,18 @@ class ResourcesApp(implicit val swagger: Swagger) extends ScalatraServlet with N
 
 object OEmbedProxyInfo {
 
-  val contactInfo = ContactInfo(
+  val contactInfo: ContactInfo = ContactInfo(
     "NDLA",
     "ndla.no",
     OEmbedProxyProperties.ContactEmail
   )
 
-  val licenseInfo = LicenseInfo(
+  val licenseInfo: LicenseInfo = LicenseInfo(
     "GPL v3.0",
     "http://www.gnu.org/licenses/gpl-3.0.en.html"
   )
 
-  val apiInfo = ApiInfo(
+  val apiInfo: ApiInfo = ApiInfo(
     "OEmbed Proxy",
     "Convert any NDLA resource to an oEmbed embeddable resource.",
     "https://om.ndla.no/tos",

--- a/src/main/scala/no/ndla/oembedproxy/controller/OEmbedProxyController.scala
+++ b/src/main/scala/no/ndla/oembedproxy/controller/OEmbedProxyController.scala
@@ -39,13 +39,13 @@ trait OEmbedProxyController {
 
     registerModel[Error]()
 
-    val response400 = ResponseMessage(400, "Validation error", Some("Error"))
-    val response401 = ResponseMessage(401, "Unauthorized")
-    val response500 = ResponseMessage(500, "Unknown error", Some("Error"))
+    val response400: ResponseMessage = ResponseMessage(400, "Validation error", Some("Error"))
+    val response401: ResponseMessage = ResponseMessage(401, "Unauthorized")
+    val response500: ResponseMessage = ResponseMessage(500, "Unknown error", Some("Error"))
 
-    val response501 =
+    val response501: ResponseMessage =
       ResponseMessage(501, "Provider Not Supported", Some("Error"))
-    val response502 = ResponseMessage(502, "Bad Gateway", Some("Error"))
+    val response502: ResponseMessage = ResponseMessage(502, "Bad Gateway", Some("Error"))
 
     case class Param(paramName: String, description: String)
 

--- a/src/main/scala/no/ndla/oembedproxy/model/NDLAErrors.scala
+++ b/src/main/scala/no/ndla/oembedproxy/model/NDLAErrors.scala
@@ -22,7 +22,7 @@ object Error {
   val PROVIDER_NOT_SUPPORTED = "PROVIDER NOT SUPPORTED"
   val REMOTE_ERROR = "REMOTE ERROR"
 
-  val GenericError = Error(
+  val GenericError: Error = Error(
     GENERIC,
     s"Ooops. Something we didn't anticipate occured. We have logged the error, and will look into it. But feel free to contact ${OEmbedProxyProperties.ContactEmail} if the error persists."
   )

--- a/src/main/scala/no/ndla/oembedproxy/model/OEmbed.scala
+++ b/src/main/scala/no/ndla/oembedproxy/model/OEmbed.scala
@@ -13,38 +13,24 @@ import org.scalatra.swagger.runtime.annotations.ApiModelProperty
 
 import scala.annotation.meta.field
 
+// format: off
 @ApiModel(description = "oEmbed information for an url.")
 case class OEmbed(
     @(ApiModelProperty @field)(description = "The resource type") `type`: String,
     @(ApiModelProperty @field)(description = "The oEmbed version number. This must be 1.0.") version: String,
     @(ApiModelProperty @field)(description = "A text title, describing the resource.") title: Option[String],
-    @(ApiModelProperty @field)(description = "A text description, describing the resource. Not standard.") description: Option[
-      String],
-    @(ApiModelProperty @field)(description = "The name of the author/owner of the resource.") authorName: Option[
-      String],
+    @(ApiModelProperty @field)(description = "A text description, describing the resource. Not standard.") description: Option[String],
+    @(ApiModelProperty @field)(description = "The name of the author/owner of the resource.") authorName: Option[String],
     @(ApiModelProperty @field)(description = "A URL for the author/owner of the resource.") authorUrl: Option[String],
     @(ApiModelProperty @field)(description = "The name of the resource provider.") providerName: Option[String],
     @(ApiModelProperty @field)(description = "The url of the resource provider.") providerUrl: Option[String],
-    @(ApiModelProperty @field)(description =
-      "The suggested cache lifetime for this resource, in seconds. Consumers may choose to use this value or not.") cacheAge: Option[
-      Long],
-    @(ApiModelProperty @field)(description =
-      "A URL to a thumbnail image representing the resource. The thumbnail must respect any maxwidth and maxheight parameters. If this parameter is present, thumbnail_width and thumbnail_height must also be present.") thumbnailUrl: Option[
-      String],
-    @(ApiModelProperty @field)(description =
-      "The width of the optional thumbnail. If this parameter is present, thumbnail_url and thumbnail_height must also be present.") thumbnailWidth: Option[
-      Long],
-    @(ApiModelProperty @field)(description =
-      "The height of the optional thumbnail. If this parameter is present, thumbnail_url and thumbnail_width must also be present.") thumbnailHeight: Option[
-      Long],
-    @(ApiModelProperty @field)(description =
-      "The source URL of the image. Consumers should be able to insert this URL into an <img> element. Only HTTP and HTTPS URLs are valid. Required if type is photo.") url: Option[
-      String],
-    @(ApiModelProperty @field)(description = "The width in pixels. Required if type is photo/video/rich") width: Option[
-      Long],
-    @(ApiModelProperty @field)(description = "The height in pixels. Required if type is photo/video/rich") height: Option[
-      Long],
-    @(ApiModelProperty @field)(description =
-      "The HTML required to embed a video player. The HTML should have no padding or margins. Consumers may wish to load the HTML in an off-domain iframe to avoid XSS vulnerabilities. Required if type is video/rich.") html: Option[
-      String]
+    @(ApiModelProperty @field)(description = "The suggested cache lifetime for this resource, in seconds. Consumers may choose to use this value or not.") cacheAge: Option[ Long],
+    @(ApiModelProperty @field)(description = "A URL to a thumbnail image representing the resource. The thumbnail must respect any maxwidth and maxheight parameters. If this parameter is present, thumbnail_width and thumbnail_height must also be present.") thumbnailUrl: Option[String],
+    @(ApiModelProperty @field)(description = "The width of the optional thumbnail. If this parameter is present, thumbnail_url and thumbnail_height must also be present.") thumbnailWidth: Option[Long],
+    @(ApiModelProperty @field)(description = "The height of the optional thumbnail. If this parameter is present, thumbnail_url and thumbnail_width must also be present.") thumbnailHeight: Option[Long],
+    @(ApiModelProperty @field)(description = "The source URL of the image. Consumers should be able to insert this URL into an <img> element. Only HTTP and HTTPS URLs are valid. Required if type is photo.") url: Option[String],
+    @(ApiModelProperty @field)(description = "The width in pixels. Required if type is photo/video/rich") width: Option[Long],
+    @(ApiModelProperty @field)(description = "The height in pixels. Required if type is photo/video/rich") height: Option[Long],
+    @(ApiModelProperty @field)(description = "The HTML required to embed a video player. The HTML should have no padding or margins. Consumers may wish to load the HTML in an off-domain iframe to avoid XSS vulnerabilities. Required if type is video/rich.") html: Option[String]
 )
+// format: on

--- a/src/main/scala/no/ndla/oembedproxy/model/OEmbedProvider.scala
+++ b/src/main/scala/no/ndla/oembedproxy/model/OEmbedProvider.scala
@@ -28,7 +28,7 @@ case class OEmbedProvider(providerName: String,
   }
 
   private def _requestUrl(url: String, maxWidth: Option[String], maxHeight: Option[String]): String = {
-    endpoints.find(_.url.isDefined) match {
+    endpoints.find(_.supports(url)).find(e => e.url.isDefined) match {
       case None =>
         throw new RuntimeException(s"The provider '$providerName' has no embed-url available")
       case Some(endpoint) =>

--- a/src/main/scala/no/ndla/oembedproxy/model/OEmbedProvider.scala
+++ b/src/main/scala/no/ndla/oembedproxy/model/OEmbedProvider.scala
@@ -28,7 +28,7 @@ case class OEmbedProvider(providerName: String,
   }
 
   private def _requestUrl(url: String, maxWidth: Option[String], maxHeight: Option[String]): String = {
-    endpoints.find(_.supports(url)).find(e => e.url.isDefined) match {
+    endpoints.collectFirst { case e if e.supports(url) && e.url.isDefined => e } match {
       case None =>
         throw new RuntimeException(s"The provider '$providerName' has no embed-url available")
       case Some(endpoint) =>

--- a/src/main/scala/no/ndla/oembedproxy/service/OEmbedServiceComponent.scala
+++ b/src/main/scala/no/ndla/oembedproxy/service/OEmbedServiceComponent.scala
@@ -11,6 +11,7 @@ package no.ndla.oembedproxy.service
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.network.NdlaClient
 import no.ndla.oembedproxy.model.{OEmbed, OEmbedProvider, ProviderNotSupportedException}
+import org.json4s.DefaultFormats
 
 import scala.util.{Failure, Try}
 import scalaj.http.{Http, HttpOptions}
@@ -20,9 +21,9 @@ trait OEmbedServiceComponent extends LazyLogging {
   val oEmbedService: OEmbedService
 
   class OEmbedService(optionalProviders: Option[List[OEmbedProvider]] = None) {
-    implicit val formats = org.json4s.DefaultFormats
+    implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
 
-    val remoteTimeout = 10 * 1000 // 10 Seconds
+    val remoteTimeout: Int = 10 * 1000 // 10 Seconds
 
     private lazy val providers = optionalProviders.toList.flatten ++ providerService
       .loadProviders()

--- a/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
+++ b/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
@@ -46,8 +46,7 @@ trait ProviderService {
     val NdlaApiProvider: OEmbedProvider =
       OEmbedProvider("NDLA Api",
                      OEmbedProxyProperties.NdlaApiOembedProvider,
-                     List(NdlaFrontendEndpoint, ListingFrontendEndpoint),
-                     removeQueryString)
+                     List(NdlaFrontendEndpoint, ListingFrontendEndpoint))
 
     val YoutubeEndpoint: OEmbedEndpoint = OEmbedEndpoint(
       Some(List("https://*.youtube.com/watch*", "https://*.youtube.com/v/*", "https://youtu.be/*")),

--- a/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
+++ b/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
@@ -31,10 +31,11 @@ trait ProviderService {
   class ProviderService extends LazyLogging {
     implicit val formats: DefaultFormats = org.json4s.DefaultFormats
 
-    val NdlaFrontendApprovedUrls: List[String] = OEmbedProxyProperties.NdlaApprovedUrl
-
     val NdlaFrontendEndpoint: OEmbedEndpoint =
-      OEmbedEndpoint(Some(NdlaFrontendApprovedUrls), Some(OEmbedProxyProperties.NdlaApiOembedServiceUrl), None, None)
+      OEmbedEndpoint(Some(OEmbedProxyProperties.NdlaApprovedUrl),
+                     Some(OEmbedProxyProperties.NdlaFrontendOembedServiceUrl),
+                     None,
+                     None)
 
     val ListingFrontendEndpoint: OEmbedEndpoint =
       OEmbedEndpoint(Some(OEmbedProxyProperties.ListingFrontendApprovedUrls),

--- a/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
+++ b/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
@@ -31,56 +31,45 @@ trait ProviderService {
   class ProviderService extends LazyLogging {
     implicit val formats: DefaultFormats = org.json4s.DefaultFormats
 
-    val HttpNdlaApprovedUrls =
-      List("http://ndla.no/*/node/*", "http://ndla.no/node/*")
+    val NdlaApiApprovedUrls: List[String] = OEmbedProxyProperties.NdlaApprovedUrl
 
-    val HttpNdlaEndpoint =
-      OEmbedEndpoint(Some(HttpNdlaApprovedUrls), Some("http://ndla.no/services/oembed"), None, None)
-    val HttpNdlaProvider = OEmbedProvider("ndla", "http://www.ndla.no", List(HttpNdlaEndpoint), removeQueryString)
-
-    val HttpsNdlaApprovedUrls =
-      List("https://ndla.no/*/node/*", "https://ndla.no/node/*")
-
-    val HttpsNdlaEndpoint =
-      OEmbedEndpoint(Some(HttpsNdlaApprovedUrls), Some("https://ndla.no/services/oembed"), None, None)
-    val HttpsNdlaProvider = OEmbedProvider("ndla", "http://www.ndla.no", List(HttpsNdlaEndpoint), removeQueryString)
-
-    val NdlaApiApprovedUrls = OEmbedProxyProperties.NdlaApprovedUrl
-
-    val NdlaApiEndpoint =
+    val NdlaApiEndpoint: OEmbedEndpoint =
       OEmbedEndpoint(Some(NdlaApiApprovedUrls), Some(OEmbedProxyProperties.NdlaApiOembedServiceUrl), None, None)
 
-    val NdlaApiProvider =
-      OEmbedProvider("NDLA Api", OEmbedProxyProperties.NdlaApiOembedProvider, List(NdlaApiEndpoint), removeQueryString)
+    val ListingFrontendEndpoint: OEmbedEndpoint =
+      OEmbedEndpoint(Some(OEmbedProxyProperties.ListingFrontendApprovedUrls),
+                     Some(OEmbedProxyProperties.ListingFrontendOembedServiceUrl),
+                     None,
+                     None)
 
-    val ListingFrontendEndpoint = OEmbedEndpoint(Some(OEmbedProxyProperties.ListingFrontendApprovedUrls),
-                                                 Some(OEmbedProxyProperties.ListingFrontendOembedServiceUrl),
-                                                 None,
-                                                 None)
+    val NdlaApiProvider: OEmbedProvider =
+      OEmbedProvider("NDLA Api",
+                     OEmbedProxyProperties.NdlaApiOembedProvider,
+                     List(NdlaApiEndpoint, ListingFrontendEndpoint),
+                     removeQueryString)
 
-    val ListingFrontendProvider =
-      OEmbedProvider("NDLA Liste", "https://liste.ndla.no", List(ListingFrontendEndpoint))
-
-    val YoutubeEndpoint =
+    val YoutubeEndpoint: OEmbedEndpoint =
       OEmbedEndpoint(None, Some("https://www.youtube.com/oembed"), None, None)
 
-    val YoutuProvider = OEmbedProvider("YouTube",
-                                       "https://youtu.be",
-                                       List(YoutubeEndpoint),
-                                       handleYoutubeRequestUrl,
-                                       addYoutubeTimestampIfdefinedInRequest)
+    val YoutuProvider: OEmbedProvider = OEmbedProvider("YouTube",
+                                                       "https://youtu.be",
+                                                       List(YoutubeEndpoint),
+                                                       handleYoutubeRequestUrl,
+                                                       addYoutubeTimestampIfdefinedInRequest)
 
-    val YoutubeProvider = OEmbedProvider("YouTube",
-                                         "https://www.youtube.com",
-                                         List(YoutubeEndpoint),
-                                         handleYoutubeRequestUrl,
-                                         addYoutubeTimestampIfdefinedInRequest)
+    val YoutubeProvider: OEmbedProvider = OEmbedProvider("YouTube",
+                                                         "https://www.youtube.com",
+                                                         List(YoutubeEndpoint),
+                                                         handleYoutubeRequestUrl,
+                                                         addYoutubeTimestampIfdefinedInRequest)
 
     val H5PApprovedUrls = List(OEmbedProxyProperties.NdlaH5PApprovedUrl)
 
-    val H5PEndpoint =
+    val H5PEndpoint: OEmbedEndpoint =
       OEmbedEndpoint(Some(H5PApprovedUrls), Some(s"${OEmbedProxyProperties.NdlaH5POembedProvider}/oembed"), None, None)
-    val H5PProvider = OEmbedProvider("H5P", OEmbedProxyProperties.NdlaH5POembedProvider, List(H5PEndpoint))
+
+    val H5PProvider: OEmbedProvider =
+      OEmbedProvider("H5P", OEmbedProxyProperties.NdlaH5POembedProvider, List(H5PEndpoint))
 
     val TedApprovedUrls = List(
       "https://www.ted.com/talks/*",
@@ -97,23 +86,25 @@ trait ProviderService {
       "embed.ted.com/talks/*"
     )
 
-    val TedEndpoint =
+    val TedEndpoint: OEmbedEndpoint =
       OEmbedEndpoint(Some(TedApprovedUrls), Some("https://www.ted.com/services/v1/oembed.json"), None, None)
-    val TedProvider = OEmbedProvider("Ted", "https://ted.com", List(TedEndpoint), removeQueryString)
+    val TedProvider: OEmbedProvider = OEmbedProvider("Ted", "https://ted.com", List(TedEndpoint), removeQueryString)
 
     val IssuuApprovedUrls = List("http://issuu.com/*", "https://issuu.com/*")
 
-    val IssuuEndpoint =
+    val IssuuEndpoint: OEmbedEndpoint =
       OEmbedEndpoint(Some(IssuuApprovedUrls), Some("https://issuu.com/oembed"), None, None, List(("iframe", "true")))
-    val IssuuProvider = OEmbedProvider("Issuu", "https://issuu.com", List(IssuuEndpoint), removeQueryStringAndFragment)
 
-    val loadProviders = Memoize(() => {
+    val IssuuProvider: OEmbedProvider =
+      OEmbedProvider("Issuu", "https://issuu.com", List(IssuuEndpoint), removeQueryStringAndFragment)
+
+    val loadProviders: Memoize[List[OEmbedProvider]] = Memoize(() => {
       logger.info("Provider cache was not found or out of date, fetching providers")
       _loadProviders()
     })
 
     def _loadProviders(): List[OEmbedProvider] = {
-      HttpNdlaProvider :: HttpsNdlaProvider :: NdlaApiProvider :: TedProvider :: H5PProvider :: YoutubeProvider :: YoutuProvider :: IssuuProvider :: loadProvidersFromRequest(
+      NdlaApiProvider :: TedProvider :: H5PProvider :: YoutubeProvider :: YoutuProvider :: IssuuProvider :: loadProvidersFromRequest(
         Http(OEmbedProxyProperties.JSonProviderUrl))
     }
 

--- a/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
+++ b/src/main/scala/no/ndla/oembedproxy/service/ProviderService.scala
@@ -31,10 +31,10 @@ trait ProviderService {
   class ProviderService extends LazyLogging {
     implicit val formats: DefaultFormats = org.json4s.DefaultFormats
 
-    val NdlaApiApprovedUrls: List[String] = OEmbedProxyProperties.NdlaApprovedUrl
+    val NdlaFrontendApprovedUrls: List[String] = OEmbedProxyProperties.NdlaApprovedUrl
 
-    val NdlaApiEndpoint: OEmbedEndpoint =
-      OEmbedEndpoint(Some(NdlaApiApprovedUrls), Some(OEmbedProxyProperties.NdlaApiOembedServiceUrl), None, None)
+    val NdlaFrontendEndpoint: OEmbedEndpoint =
+      OEmbedEndpoint(Some(NdlaFrontendApprovedUrls), Some(OEmbedProxyProperties.NdlaApiOembedServiceUrl), None, None)
 
     val ListingFrontendEndpoint: OEmbedEndpoint =
       OEmbedEndpoint(Some(OEmbedProxyProperties.ListingFrontendApprovedUrls),
@@ -45,17 +45,14 @@ trait ProviderService {
     val NdlaApiProvider: OEmbedProvider =
       OEmbedProvider("NDLA Api",
                      OEmbedProxyProperties.NdlaApiOembedProvider,
-                     List(NdlaApiEndpoint, ListingFrontendEndpoint),
+                     List(NdlaFrontendEndpoint, ListingFrontendEndpoint),
                      removeQueryString)
 
-    val YoutubeEndpoint: OEmbedEndpoint =
-      OEmbedEndpoint(None, Some("https://www.youtube.com/oembed"), None, None)
-
-    val YoutuProvider: OEmbedProvider = OEmbedProvider("YouTube",
-                                                       "https://youtu.be",
-                                                       List(YoutubeEndpoint),
-                                                       handleYoutubeRequestUrl,
-                                                       addYoutubeTimestampIfdefinedInRequest)
+    val YoutubeEndpoint: OEmbedEndpoint = OEmbedEndpoint(
+      Some(List("https://*.youtube.com/watch*", "https://*.youtube.com/v/*", "https://youtu.be/*")),
+      Some("https://www.youtube.com/oembed"),
+      None,
+      None)
 
     val YoutubeProvider: OEmbedProvider = OEmbedProvider("YouTube",
                                                          "https://www.youtube.com",
@@ -104,7 +101,7 @@ trait ProviderService {
     })
 
     def _loadProviders(): List[OEmbedProvider] = {
-      NdlaApiProvider :: TedProvider :: H5PProvider :: YoutubeProvider :: YoutuProvider :: IssuuProvider :: loadProvidersFromRequest(
+      NdlaApiProvider :: TedProvider :: H5PProvider :: YoutubeProvider :: IssuuProvider :: loadProvidersFromRequest(
         Http(OEmbedProxyProperties.JSonProviderUrl))
     }
 

--- a/src/test/scala/no/ndla/oembedproxy/TestEnvironment.scala
+++ b/src/test/scala/no/ndla/oembedproxy/TestEnvironment.scala
@@ -21,11 +21,11 @@ trait TestEnvironment
     with ProviderService
     with MockitoSugar
     with HealthController {
-  val oEmbedService = mock[OEmbedService]
-  val oEmbedProxyController = mock[OEmbedProxyController]
-  val ndlaClient = mock[NdlaClient]
-  val providerService = mock[ProviderService]
-  val healthController = mock[HealthController]
+  val oEmbedService: OEmbedService = mock[OEmbedService]
+  val oEmbedProxyController: OEmbedProxyController = mock[OEmbedProxyController]
+  val ndlaClient: NdlaClient = mock[NdlaClient]
+  val providerService: ProviderService = mock[ProviderService]
+  val healthController: HealthController = mock[HealthController]
 
   def resetMocks() = {
     Mockito.reset(oEmbedService, oEmbedProxyController, ndlaClient, providerService)

--- a/src/test/scala/no/ndla/oembedproxy/model/OEmbedEndpointTest.scala
+++ b/src/test/scala/no/ndla/oembedproxy/model/OEmbedEndpointTest.scala
@@ -21,7 +21,7 @@ class OEmbedEndpointTest extends UnitSuite {
     dummyEndpoint.matches("a.*.c", "a.b.c") should be(right = true)
   }
 
-  test("That matches returns true for a non-matching expression") {
+  test("That matches returns false for a non-matching expression") {
     dummyEndpoint.matches("http://www.ndla.no/*/test", "http://www.ndla.no/test") should be(right = false)
     dummyEndpoint.matches("http://www.ndla.no/*/test/*", "https://www.ndla.no/nb/test/123") should be(right = false)
   }

--- a/src/test/scala/no/ndla/oembedproxy/model/OEmbedEndpointTest.scala
+++ b/src/test/scala/no/ndla/oembedproxy/model/OEmbedEndpointTest.scala
@@ -12,7 +12,7 @@ import no.ndla.oembedproxy.UnitSuite
 
 class OEmbedEndpointTest extends UnitSuite {
 
-  val dummyEndpoint = OEmbedEndpoint(None, None, None, None)
+  val dummyEndpoint: OEmbedEndpoint = OEmbedEndpoint(None, None, None, None)
 
   test("That matches returns true for a matching expression") {
     dummyEndpoint.matches("http://www.ndla.no/*/test", "http://www.ndla.no/123123/test") should be(right = true)

--- a/src/test/scala/no/ndla/oembedproxy/model/OEmbedProviderTest.scala
+++ b/src/test/scala/no/ndla/oembedproxy/model/OEmbedProviderTest.scala
@@ -13,13 +13,13 @@ import no.ndla.oembedproxy.UnitSuite
 class OEmbedProviderTest extends UnitSuite {
 
   val youtubeProvider: OEmbedProvider =
-    OEmbedProvider("youtube", "http://www.youtube.com", List())
+    OEmbedProvider("youtube", "https://www.youtube.com", List())
 
   val ndlaEndpoint: OEmbedEndpoint =
-    OEmbedEndpoint(Some(List("http://www.ndla.no/*/123")), None, None, None)
+    OEmbedEndpoint(Some(List("https://www.ndla.no/*/123")), Some("https://ndla.no/oembed"), None, None)
 
   val youtubeEndpoint: OEmbedEndpoint =
-    OEmbedEndpoint(Some(List("http://www.youtube.com/*")), None, None, None)
+    OEmbedEndpoint(Some(List("https://www.youtube.com/*")), Some("https://www.youtube.com/oembed"), None, None)
 
   test("That hostMatches returns true for same host, regardless of protocol") {
     youtubeProvider.hostMatches("https://www.youtube.com") should be(right = true)
@@ -35,19 +35,19 @@ class OEmbedProviderTest extends UnitSuite {
   }
 
   test("That supports returns true when host matches") {
-    youtubeProvider.supports("http://www.youtube.com") should be(right = true)
+    youtubeProvider.supports("https://www.youtube.com") should be(right = true)
   }
 
   test("That supports returns true when endpoints matches") {
     youtubeProvider
       .copy(endpoints = List(ndlaEndpoint))
-      .supports("http://www.ndla.no/nb/123") should be(right = true)
+      .supports("https://www.ndla.no/nb/123") should be(right = true)
   }
 
   test("That support returns false when neither endpoints or host matches") {
     youtubeProvider
       .copy(endpoints = List(youtubeEndpoint))
-      .supports("http://www.ndla.no/nb/123") should be(right = false)
+      .supports("https://www.ndla.no/nb/123") should be(right = false)
   }
 
   test("That requestUrl throws exception when no endpoints have embedUrl defined") {
@@ -60,34 +60,35 @@ class OEmbedProviderTest extends UnitSuite {
 
   test("That {format} is replaced in embedUrl") {
     val endpoint =
-      youtubeEndpoint.copy(url = Some("http://www.youtube.com/oembed.{format}"))
+      youtubeEndpoint.copy(url = Some("https://www.youtube.com/oembed.{format}"))
     val requestUrl = youtubeProvider
       .copy(endpoints = List(endpoint))
-      .requestUrl("ABC", None, None)
-    requestUrl should equal("http://www.youtube.com/oembed.json?url=ABC&format=json")
+      .requestUrl("https://www.youtube.com/v/ABC", None, None)
+    requestUrl should equal("https://www.youtube.com/oembed.json?url=https://www.youtube.com/v/ABC&format=json")
   }
 
   test("That maxwidth is appended correctly") {
-    val endpoint = youtubeEndpoint.copy(url = Some("http://youtube.com/oembed"))
+    val endpoint = youtubeEndpoint.copy(url = Some("https://youtube.com/oembed"))
     val requestUrl = youtubeProvider
       .copy(endpoints = List(endpoint))
-      .requestUrl("ABC", Some("100"), None)
-    requestUrl should equal("http://youtube.com/oembed?url=ABC&format=json&maxwidth=100")
+      .requestUrl("https://www.youtube.com/v/ABC", Some("100"), None)
+    requestUrl should equal("https://youtube.com/oembed?url=https://www.youtube.com/v/ABC&format=json&maxwidth=100")
   }
 
   test("That maxheight is appended correctly") {
-    val endpoint = youtubeEndpoint.copy(url = Some("http://youtube.com/oembed"))
+    val endpoint = youtubeEndpoint.copy(url = Some("https://youtube.com/oembed"))
     val requestUrl = youtubeProvider
       .copy(endpoints = List(endpoint))
-      .requestUrl("ABC", None, Some("100"))
-    requestUrl should equal("http://youtube.com/oembed?url=ABC&format=json&maxheight=100")
+      .requestUrl("https://www.youtube.com/v/ABC", None, Some("100"))
+    requestUrl should equal("https://youtube.com/oembed?url=https://www.youtube.com/v/ABC&format=json&maxheight=100")
   }
 
   test("That both maxwidth and maxheight are appended correctly") {
-    val endpoint = youtubeEndpoint.copy(url = Some("http://youtube.com/oembed"))
+    val endpoint = youtubeEndpoint.copy(url = Some("https://youtube.com/oembed"))
     val requestUrl = youtubeProvider
       .copy(endpoints = List(endpoint))
-      .requestUrl("ABC", Some("100"), Some("200"))
-    requestUrl should equal("http://youtube.com/oembed?url=ABC&format=json&maxwidth=100&maxheight=200")
+      .requestUrl("https://www.youtube.com/v/ABC", Some("100"), Some("200"))
+    requestUrl should equal(
+      "https://youtube.com/oembed?url=https://www.youtube.com/v/ABC&format=json&maxwidth=100&maxheight=200")
   }
 }

--- a/src/test/scala/no/ndla/oembedproxy/model/OEmbedProviderTest.scala
+++ b/src/test/scala/no/ndla/oembedproxy/model/OEmbedProviderTest.scala
@@ -16,7 +16,10 @@ class OEmbedProviderTest extends UnitSuite {
     OEmbedProvider("youtube", "https://www.youtube.com", List())
 
   val ndlaEndpoint: OEmbedEndpoint =
-    OEmbedEndpoint(Some(List("https://www.ndla.no/*/123")), Some("https://ndla.no/oembed"), None, None)
+    OEmbedEndpoint(Some(List("https://ndla.no/*/123")), Some("https://ndla.no/oembed"), None, None)
+
+  val ndlaListEndpoint: OEmbedEndpoint =
+    OEmbedEndpoint(Some(List("https://liste.ndla.no/*")), Some("https://liste.ndla.no/oembed"), None, None)
 
   val youtubeEndpoint: OEmbedEndpoint =
     OEmbedEndpoint(Some(List("https://www.youtube.com/*")), Some("https://www.youtube.com/oembed"), None, None)
@@ -39,9 +42,9 @@ class OEmbedProviderTest extends UnitSuite {
   }
 
   test("That supports returns true when endpoints matches") {
-    youtubeProvider
-      .copy(endpoints = List(ndlaEndpoint))
-      .supports("https://www.ndla.no/nb/123") should be(right = true)
+    val provider = youtubeProvider.copy(endpoints = List(ndlaEndpoint, ndlaListEndpoint))
+    provider.supports("https://ndla.no/nb/123") should be(right = true)
+    provider.supports("https://liste.ndla.no/nb/123") should be(right = true)
   }
 
   test("That support returns false when neither endpoints or host matches") {

--- a/src/test/scala/no/ndla/oembedproxy/model/OEmbedProviderTest.scala
+++ b/src/test/scala/no/ndla/oembedproxy/model/OEmbedProviderTest.scala
@@ -12,19 +12,14 @@ import no.ndla.oembedproxy.UnitSuite
 
 class OEmbedProviderTest extends UnitSuite {
 
-  val youtubeProvider =
+  val youtubeProvider: OEmbedProvider =
     OEmbedProvider("youtube", "http://www.youtube.com", List())
 
-  val ndlaEndpoint =
+  val ndlaEndpoint: OEmbedEndpoint =
     OEmbedEndpoint(Some(List("http://www.ndla.no/*/123")), None, None, None)
 
-  val youtubeEndpoint =
+  val youtubeEndpoint: OEmbedEndpoint =
     OEmbedEndpoint(Some(List("http://www.youtube.com/*")), None, None, None)
-
-  val goOpenEndpoint = OEmbedEndpoint(None, Some("http://www.goopen.no/"), None, None, List(("oembed", "true")))
-
-  val goOpenProvider =
-    OEmbedProvider("GoOpen.no", "http://www.goopen.no", goOpenEndpoint :: Nil)
 
   test("That hostMatches returns true for same host, regardless of protocol") {
     youtubeProvider.hostMatches("https://www.youtube.com") should be(right = true)
@@ -94,13 +89,5 @@ class OEmbedProviderTest extends UnitSuite {
       .copy(endpoints = List(endpoint))
       .requestUrl("ABC", Some("100"), Some("200"))
     requestUrl should equal("http://youtube.com/oembed?url=ABC&format=json&maxwidth=100&maxheight=200")
-  }
-
-  test("That mandatoryQueryParams are added when they are defined") {
-    val toOembed =
-      "http://www.goopen.no/the-true-pioneers-of-the-sharing-economy"
-    val expectedRequestUrl =
-      "http://www.goopen.no/?url=http://www.goopen.no/the-true-pioneers-of-the-sharing-economy&format=json&oembed=true"
-    goOpenProvider.requestUrl(toOembed, None, None) should equal(expectedRequestUrl)
   }
 }

--- a/src/test/scala/no/ndla/oembedproxy/service/OEmbedServiceTest.scala
+++ b/src/test/scala/no/ndla/oembedproxy/service/OEmbedServiceTest.scala
@@ -21,16 +21,15 @@ import scalaj.http.HttpRequest
 
 class OEmbedServiceTest extends UnitSuite with TestEnvironment {
 
-  val ndlaProvider = OEmbedProvider("ndla",
-                                    "http://ndla.no",
-                                    List(OEmbedEndpoint(None, Some("http://ndla.no/services/oembed"), None, None)))
+  val ndlaProvider: OEmbedProvider =
+    OEmbedProvider("ndla", "http://ndla.no", List(OEmbedEndpoint(None, Some("http://ndla.no/oembed"), None, None)))
 
-  val youtubeProvider = OEmbedProvider(
+  val youtubeProvider: OEmbedProvider = OEmbedProvider(
     "YouTube",
     "https://www.youtube.com/",
     List(OEmbedEndpoint(None, Some("https://www.youtube.com/oembed"), Some(true), None)))
 
-  val OEmbedResponse = OEmbed(
+  val OEmbedResponse: OEmbed = OEmbed(
     "rich",
     "1.0",
     Some("A Confectioner in the UK"),
@@ -51,8 +50,8 @@ class OEmbedServiceTest extends UnitSuite with TestEnvironment {
 
   override val oEmbedService = new OEmbedService(Some(List(ndlaProvider, youtubeProvider)))
   val providerMemoize = new Memoize(0, 0, () => List[OEmbedProvider](), false)
-  override val providerService = new ProviderService {
-    override val loadProviders = providerMemoize
+  override val providerService: ProviderService = new ProviderService {
+    override val loadProviders: Memoize[List[OEmbedProvider]] = providerMemoize
   }
 
   test("That get returns Failure(ProviderNotSupportedException) when no providers support the url") {

--- a/src/test/scala/no/ndla/oembedproxy/service/OEmbedServiceTest.scala
+++ b/src/test/scala/no/ndla/oembedproxy/service/OEmbedServiceTest.scala
@@ -21,13 +21,17 @@ import scalaj.http.HttpRequest
 
 class OEmbedServiceTest extends UnitSuite with TestEnvironment {
 
-  val ndlaProvider: OEmbedProvider =
-    OEmbedProvider("ndla", "http://ndla.no", List(OEmbedEndpoint(None, Some("http://ndla.no/oembed"), None, None)))
+  val ndlaProvider: OEmbedProvider = OEmbedProvider(
+    "ndla",
+    "https://ndla.no",
+    List(OEmbedEndpoint(Some(List("https://ndla.no/*")), Some("https://ndla.no/oembed"), None, None)))
 
   val youtubeProvider: OEmbedProvider = OEmbedProvider(
     "YouTube",
     "https://www.youtube.com/",
-    List(OEmbedEndpoint(None, Some("https://www.youtube.com/oembed"), Some(true), None)))
+    List(
+      OEmbedEndpoint(Some(List("https://www.youtube.com/*")), Some("https://www.youtube.com/oembed"), Some(true), None))
+  )
 
   val OEmbedResponse: OEmbed = OEmbed(
     "rich",
@@ -64,7 +68,7 @@ class OEmbedServiceTest extends UnitSuite with TestEnvironment {
   test("That get returns a failure with HttpRequestException when receiving http error") {
     when(ndlaClient.fetch[OEmbed](any[HttpRequest])(any[Manifest[OEmbed]]))
       .thenReturn(Failure(new HttpRequestException("An error occured")))
-    val oembedTry = oEmbedService.get("http://www.youtube.com/abc", None, None)
+    val oembedTry = oEmbedService.get("https://www.youtube.com/abc", None, None)
     oembedTry.isFailure should be(true)
     oembedTry.failure.exception.getMessage should equal("An error occured")
   }
@@ -72,7 +76,7 @@ class OEmbedServiceTest extends UnitSuite with TestEnvironment {
   test("That get returns a Success with an oEmbed when http call is successful") {
     when(ndlaClient.fetch[OEmbed](any[HttpRequest])(any[Manifest[OEmbed]]))
       .thenReturn(Success(OEmbedResponse))
-    val oembedTry = oEmbedService.get("http://ndla.no/abc", None, None)
+    val oembedTry = oEmbedService.get("https://ndla.no/abc", None, None)
     oembedTry.isSuccess should be(true)
     oembedTry.get.`type` should equal("rich")
     oembedTry.get.title.getOrElse("") should equal("A Confectioner in the UK")

--- a/src/test/scala/no/ndla/oembedproxy/service/ProviderServiceTest.scala
+++ b/src/test/scala/no/ndla/oembedproxy/service/ProviderServiceTest.scala
@@ -19,11 +19,12 @@ import scalaj.http.{Http, HttpRequest}
 
 class ProviderServiceTest extends UnitSuite with TestEnvironment {
 
-  val IncompleteProvider = OEmbedProvider("gfycat",
-                                          "https://gfycat.com",
-                                          List(OEmbedEndpoint(Some(List("http://gfycat.com/*")), None, None, None)))
+  val IncompleteProvider: OEmbedProvider = OEmbedProvider(
+    "gfycat",
+    "https://gfycat.com",
+    List(OEmbedEndpoint(Some(List("http://gfycat.com/*")), None, None, None)))
 
-  val CompleteProvider = OEmbedProvider(
+  val CompleteProvider: OEmbedProvider = OEmbedProvider(
     "IFTTT",
     "http://www.ifttt.com",
     List(


### PR DESCRIPTION
Fjerner providers som ikkje lenger finnes. Legger på annotasjoner på val.

Slår sammen endpoints for ndla.no og liste.ndla.no til samme provider. Eg stussa på at eg fikk feilmelding ved bruk av oembed-proxy i test: Could not find an oembed-provider for the url 'https://liste.test.ndla.no/?concept=603' når denne ligger inne. Dagens oppsett godkjenner kun liste.ndla.no som provider, men oppdatert skal ta hensyn til env.

Fjerna parameterstripping for ndla-urler for lister er avhengig av det, mens ndla-frontend ignorerer det.